### PR TITLE
Fix UV index

### DIFF
--- a/adafruit_si1145.py
+++ b/adafruit_si1145.py
@@ -124,10 +124,10 @@ class SI1145:
         self._param_set(_RAM_CHLIST, chlist)
         self._als_enabled = enable
 
-        self._ucoeff_0 = 0x29,
-        self._ucoeff_1 = 0x89,
-        self._ucoeff_2 = 0x02,
-        self._ucoeff_3 = 0x00,
+        self._ucoeff_0 = (0x29,)
+        self._ucoeff_1 = (0x89,)
+        self._ucoeff_2 = (0x02,)
+        self._ucoeff_3 = (0x00,)
 
         self._uv_index_enabled = enable
 

--- a/adafruit_si1145.py
+++ b/adafruit_si1145.py
@@ -118,20 +118,23 @@ class SI1145:
     def uv_index_enabled(self, enable):
         chlist = self._param_query(_RAM_CHLIST)
         if enable:
-            chlist |= 0b01000000
+            chlist |= 0b10000000
         else:
-            chlist &= ~0b01000000
+            chlist &= ~0b10000000
         self._param_set(_RAM_CHLIST, chlist)
         self._als_enabled = enable
 
-        self._ucoeff_0 = 0x00
-        self._ucoeff_1 = 0x02
-        self._ucoeff_2 = 0x89
-        self._ucoeff_3 = 0x29
+        self._ucoeff_0 = 0x29,
+        self._ucoeff_1 = 0x89,
+        self._ucoeff_2 = 0x02,
+        self._ucoeff_3 = 0x00,
+
+        self._uv_index_enabled = enable
 
     @property
     def uv_index(self):
         """The UV Index value"""
+        self._send_command(_CMD_ALS_FORCE)
         return self._aux_data[0] / 100
 
     def reset(self):


### PR DESCRIPTION
For #9. Should hopefully get UV index reading working.

Main things done: 
* Incorrect bit being set in CHLIST for enabling UV index (off by one)
* The `ucoeff` values were set in wrong order (datasheet is confusing on this, order determined by trial and error)
  * Values also needed to be tuples instead of ints
* Needed to force an ALS reading to update UV index value

Tested:
```python
Adafruit CircuitPython 7.3.2 on 2022-07-20; Adafruit QT Py M0 with samd21e18
>>> import board
>>> import adafruit_si1145
>>> si = adafruit_si1145.SI1145(board.I2C())
>>> si.uv_index
0.08
>>> si.uv_index
0.78
>>> si.uv_index
5.09
>>> 
```